### PR TITLE
feat(theme): sync Chakra UI color mode with Docusaurus on initial load

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -1,8 +1,9 @@
-import {themes as prismThemes} from 'prism-react-renderer';
-import type {Config} from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
-import remarkMath from 'remark-math';
+import type { Config } from '@docusaurus/types';
+import { themes as prismThemes } from 'prism-react-renderer';
 import rehypeKatex from 'rehype-katex';
+import remarkMath from 'remark-math';
+import { getChakraThemeSyncPlugin } from './src/plugins/chakra-theme-sync';
 
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 
@@ -27,7 +28,6 @@ const config: Config = {
     mermaid: true,
   },
   themes: ['@docusaurus/theme-mermaid'],
-
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you
@@ -59,6 +59,7 @@ const config: Config = {
   ],
 
   plugins: [
+    getChakraThemeSyncPlugin,
     [
       '@docusaurus/plugin-content-docs',
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@emotion/react": "^11.14.0",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
+        "common-tags": "^1.8.2",
         "html-entities": "^2.5.2",
         "next-themes": "^0.4.4",
         "prism-react-renderer": "^2.3.0",
@@ -30,6 +31,7 @@
         "@docusaurus/module-type-aliases": "3.7.0",
         "@docusaurus/tsconfig": "3.7.0",
         "@docusaurus/types": "3.7.0",
+        "@types/common-tags": "^1.8.4",
         "typescript": "~5.6.2"
       },
       "engines": {
@@ -4841,6 +4843,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/common-tags": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/@types/common-tags/-/common-tags-1.8.4.tgz",
+      "integrity": "sha512-S+1hLDJPjWNDhcGxsxEbepzaxWqURP/o+3cP4aa2w7yBXgdcmKGQtZzP8JbyfOd0m+33nh+8+kvxYE2UJtBDkg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -7589,6 +7598,15 @@
       "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
       "integrity": "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==",
       "license": "ISC"
+    },
+    "node_modules/common-tags": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
+      "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
     },
     "node_modules/compressible": {
       "version": "2.0.18",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@emotion/react": "^11.14.0",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
+    "common-tags": "^1.8.2",
     "html-entities": "^2.5.2",
     "next-themes": "^0.4.4",
     "prism-react-renderer": "^2.3.0",
@@ -37,6 +38,7 @@
     "@docusaurus/module-type-aliases": "3.7.0",
     "@docusaurus/tsconfig": "3.7.0",
     "@docusaurus/types": "3.7.0",
+    "@types/common-tags": "^1.8.4",
     "typescript": "~5.6.2"
   },
   "browserslist": {

--- a/src/components/ui/color-mode.tsx
+++ b/src/components/ui/color-mode.tsx
@@ -1,79 +1,18 @@
-"use client"
+'use client';
 
-import type { IconButtonProps, SpanProps } from "@chakra-ui/react"
-import { ClientOnly, IconButton, Skeleton, Span } from "@chakra-ui/react"
-import type { ThemeProviderProps } from "next-themes"
-import { ThemeProvider, useTheme } from "next-themes"
-import * as React from "react"
-import { useEffect } from "react"
-import { LuMoon, LuSun } from "react-icons/lu"
+import type { SpanProps } from '@chakra-ui/react';
+import { Span } from '@chakra-ui/react';
+import type { ThemeProviderProps } from 'next-themes';
+import { ThemeProvider } from 'next-themes';
+import * as React from 'react';
 
-export interface ColorModeProviderProps extends ThemeProviderProps { }
+export interface ColorModeProviderProps extends ThemeProviderProps {}
 
 export function ColorModeProvider(props: ColorModeProviderProps) {
   return (
     <ThemeProvider attribute="class" disableTransitionOnChange {...props} />
-  )
+  );
 }
-
-export type ColorMode = "light" | "dark"
-
-export interface UseColorModeReturn {
-  colorMode: ColorMode
-  setColorMode: (colorMode: ColorMode) => void
-  toggleColorMode: () => void
-}
-
-export function useColorMode(): UseColorModeReturn {
-  const { resolvedTheme, setTheme } = useTheme()
-  const toggleColorMode = () => {
-    setTheme(resolvedTheme === "dark" ? "light" : "dark")
-  }
-  return {
-    colorMode: resolvedTheme as ColorMode,
-    setColorMode: setTheme,
-    toggleColorMode,
-  }
-}
-
-export function useColorModeValue<T>(light: T, dark: T) {
-  const { colorMode } = useColorMode()
-  return colorMode === "dark" ? dark : light
-}
-
-export function ColorModeIcon() {
-  const { colorMode } = useColorMode()
-  return colorMode === "dark" ? <LuMoon /> : <LuSun />
-}
-
-interface ColorModeButtonProps extends Omit<IconButtonProps, "aria-label"> { }
-
-export const ColorModeButton = React.forwardRef<
-  HTMLButtonElement,
-  ColorModeButtonProps
->(function ColorModeButton(props, ref) {
-  const { toggleColorMode } = useColorMode()
-  return (
-    <ClientOnly fallback={<Skeleton boxSize="8" />}>
-      <IconButton
-        onClick={toggleColorMode}
-        variant="ghost"
-        aria-label="Toggle color mode"
-        size="sm"
-        ref={ref}
-        {...props}
-        css={{
-          _icon: {
-            width: "5",
-            height: "5",
-          },
-        }}
-      >
-        <ColorModeIcon />
-      </IconButton>
-    </ClientOnly>
-  )
-})
 
 export const LightMode = React.forwardRef<HTMLSpanElement, SpanProps>(
   function LightMode(props, ref) {
@@ -87,9 +26,9 @@ export const LightMode = React.forwardRef<HTMLSpanElement, SpanProps>(
         ref={ref}
         {...props}
       />
-    )
+    );
   },
-)
+);
 
 export const DarkMode = React.forwardRef<HTMLSpanElement, SpanProps>(
   function DarkMode(props, ref) {
@@ -103,6 +42,6 @@ export const DarkMode = React.forwardRef<HTMLSpanElement, SpanProps>(
         ref={ref}
         {...props}
       />
-    )
+    );
   },
-)
+);

--- a/src/plugins/chakra-theme-sync/index.ts
+++ b/src/plugins/chakra-theme-sync/index.ts
@@ -1,0 +1,64 @@
+import { Plugin } from '@docusaurus/types';
+import { stripIndent } from 'common-tags';
+
+/**
+ * Chakra UI v3 requires a `.light` or `.dark` class on the `<html>` element in order
+ * to apply color mode–specific CSS variables. It no longer uses `ColorModeScript`,
+ * nor does it read from a `data-theme` attribute.
+ *
+ * This site uses Docusaurus, which manages its color mode independently via a
+ * `data-theme="light" | "dark"` attribute and persists user preference using localStorage.
+ *
+ * We're also using `next-themes` to manage color mode for Chakra. However,
+ * `next-themes` expects either a `class` (e.g., `.light` / `.dark`) or `data-theme`
+ * attribute to exist on `<html>`, and Chakra specifically requires the class.
+ *
+ * On initial load, Docusaurus sets `data-theme` via an inline script, but it does not
+ * set a corresponding `.light` or `.dark` class. Even worse, it uses `react-helmet`
+ * to manage the `<html>` element during hydration, which clobbers any manually added
+ * class attributes (including those added in early scripts).
+ *
+ * This plugin injects a small inline script that:
+ *   - Mirrors the value of `data-theme` to a `.light` or `.dark` class on `<html>`
+ *   - Reacts to changes to `data-theme` or `class` (e.g., theme toggles, hydration)
+ *   - Re-applies the correct theme class if it gets clobbered by React Helmet
+ *   - Avoids infinite mutation loops by checking before updating
+ *
+ * This ensures Chakra and `next-themes` both function correctly while Docusaurus
+ * remains the source of truth for theme state (via `data-theme`).
+ */
+export function getChakraThemeSyncPlugin() {
+  return {
+    name: 'chakra-theme-sync',
+    injectHtmlTags: () => ({
+      preBodyTags: [
+        {
+          tagName: 'script',
+          innerHTML: stripIndent`
+						(() => {
+              const attributeFilter = ['data-theme', 'class'];
+              const themes = ['light', 'dark'];
+              const html = document.documentElement;
+              function applyThemeClass() {
+                const theme = html.getAttribute('data-theme');
+                if (!themes.includes(theme) || html.classList.contains(theme)) return;
+
+                const remove = themes.filter(t => t !== theme);
+                html.classList.remove(...remove);
+                html.classList.add(theme);
+              }
+              applyThemeClass();
+              new MutationObserver(mutations => {
+                for (const m of mutations) {
+                  if (attributeFilter.includes(m.attributeName)) {
+                    applyThemeClass();
+                    return;
+                  }
+                }
+              }).observe(html, { attributes: true, attributeFilter });
+            })();`,
+        },
+      ],
+    }),
+  } satisfies Plugin;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2498,6 +2498,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/common-tags@^1.8.4":
+  version "1.8.4"
+  resolved "https://registry.npmjs.org/@types/common-tags/-/common-tags-1.8.4.tgz"
+  integrity sha512-S+1hLDJPjWNDhcGxsxEbepzaxWqURP/o+3cP4aa2w7yBXgdcmKGQtZzP8JbyfOd0m+33nh+8+kvxYE2UJtBDkg==
+
 "@types/connect-history-api-fallback@^1.3.5":
   version "1.5.4"
   resolved "https://registry.npmjs.org/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.5.4.tgz"
@@ -4503,6 +4508,11 @@ common-path-prefix@^3.0.0:
   resolved "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz"
   integrity sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==
 
+common-tags@^1.8.2:
+  version "1.8.2"
+  resolved "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz"
+  integrity sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==
+
 compressible@~2.0.18:
   version "2.0.18"
   resolved "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz"
@@ -6015,11 +6025,6 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
-
-fsevents@~2.3.2:
-  version "2.3.3"
-  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
-  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 function-bind@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
- Added `getChakraThemeSyncPlugin` to the Docusaurus config to sync `html[data-theme]` with Chakra UI on startup.
- Fixed mismatch where Chakra would default to light mode until the user toggled the theme, despite Docusaurus respecting `prefers-color-scheme`.
- Removed unused color mode utilities and icon/button components now obsolete.
- Added `common-tags` (and its types) for cleaner string formatting in plugin logic.
- Reordered and cleaned up imports for consistency.

This resolves an issue where Chakra UI initially rendered in light mode even when dark mode was preferred or set by Docusaurus, correcting the theme only after interaction.