### PR TITLE
Changed support.encryptorN to S.encryptorN

### DIFF
--- a/lab/2.md
+++ b/lab/2.md
@@ -16,16 +16,16 @@ You’ve stumbled upon a malfunctioning encryption device that scrambles secret 
 
 ## How it works
 
-The device exposes ten functions, named `support.encryptor1` through `support.encryptor10`.
+The device exposes ten functions, named `S.encryptor1` through `S.encryptor10`.
 
 Each encryptor takes in a `String` and returns a new, “encrypted” `String`.
-Alongside each encryptor, there’s a corresponding tester routine — `support.test-encryptor1`, `support.test-encryptor2`, and so on that — checks whether your replication matches the original for all possible inputs.
+Alongside each encryptor, there’s a corresponding tester routine — `S.test-encryptor1`, `S.test-encryptor2`, and so on that — checks whether your replication matches the original for all possible inputs.
 
 ## Instructions
 
 1. **Experiment**
 
-   1. Call each `support.encryptorN` with a variety of sample strings.
+   1. Call each `S.encryptorN` with a variety of sample strings.
    2. Observe how the output changes and identify the pattern or rule it applies.
    3. Keep a written log of the inputs you tried and the outputs you observed (remember, you are acting as a detective here!).
 
@@ -46,7 +46,7 @@ Alongside each encryptor, there’s a corresponding tester routine — `support.
    1. Pass your function to the provided tester:
 
 ```pyret
-support.test-encryptor1(my-encryptor1)
+S.test-encryptor1(my-encryptor1)
 ```
 
 If the tester completes without errors, your encryption logic is correct!


### PR DESCRIPTION
The support module is imported as `S` in the assingment repo.

```arr
import file("lab2-support.arr") as S
```